### PR TITLE
Improve quick quiz error handling

### DIFF
--- a/frontend/src/components/home/ExamCreationWizard.quick-quiz.tsx
+++ b/frontend/src/components/home/ExamCreationWizard.quick-quiz.tsx
@@ -997,11 +997,12 @@ export default function ExamCreationWizard({
         } else {
           setErrorMessage("Sınav oluşturuldu ancak ID alınamadı.");
         }
-      } catch (error) {
-    
-        
-   
-      }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error("Sınav oluşturulurken hata:", message);
+          toast.error("Sınav oluşturulurken bir hata oluştu.");
+          setErrorMessage(`Sınav oluşturulurken bir hata oluştu: ${message}`);
+        }
     } catch (error) {
       setErrorMessage(`Beklenmeyen hata: ${error instanceof Error ? error.message : String(error)}`);
 


### PR DESCRIPTION
## Summary
- surface API errors when creating quick quizzes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fffe0fa8832794de7c5fb3147508