### PR TITLE
Align batch update endpoint and DTO fields

### DIFF
--- a/backend/src/learning-targets/learning-targets.controller.ts
+++ b/backend/src/learning-targets/learning-targets.controller.ts
@@ -1301,7 +1301,7 @@ export class LearningTargetsController {
     }
   }
 
-  @Patch('batch-update')
+  @Post('batch-update')
   @ApiOperation({
     summary: 'Öğrenme hedeflerini toplu olarak günceller',
     description: 'Quiz sonuçlarına göre öğrenme hedeflerinin durumlarını ve puanlarını toplu olarak günceller'

--- a/frontend/src/app/exams/[id]/page.tsx
+++ b/frontend/src/app/exams/[id]/page.tsx
@@ -565,9 +565,9 @@ export default function ExamPage() {
             if (updatedTargets.length > 0) {
               // Convert TemporaryLearningTarget format to new API format
               const convertedTargets = updatedTargets.map(target => ({
-                subTopicName: target.subTopic,
+                subTopic: target.subTopic,
                 status: target.status.toLowerCase() as 'pending' | 'failed' | 'medium' | 'mastered',
-                lastScore: target.score
+                score: target.score
               }));
               
               console.log('[Learning Targets] Converted targets for new API:', convertedTargets);

--- a/frontend/src/services/learningTarget.service.ts
+++ b/frontend/src/services/learningTarget.service.ts
@@ -1165,10 +1165,10 @@ class LearningTargetService {
   // Batch update öğrenme hedefleri - Yeni API endpoint için
   @LogMethod('LearningTargetService', FlowCategory.API)
   async batchUpdateTargets(targets: Array<{
-    subTopicName: string;
-    status: 'pending' | 'failed' | 'medium' | 'mastered';
-    lastScore?: number;
-  }>): Promise<{ success: boolean; processedCount: number }> {
+      subTopic: string;
+      status: 'pending' | 'failed' | 'medium' | 'mastered';
+      score?: number;
+    }>): Promise<{ success: boolean; processedCount: number }> {
     console.group('🔄 [LearningTargetService] batchUpdateTargets - BAŞLADI');
     console.log('📋 Parametreler:', {
       targetCount: targets.length,
@@ -1204,10 +1204,10 @@ class LearningTargetService {
         1185,
         { 
           count: targets.length,
-          targets: targets.map(t => ({ 
-            subTopicName: t.subTopicName, 
-            status: t.status.toLowerCase(), 
-            lastScore: t.lastScore 
+          targets: targets.map(t => ({
+            subTopic: t.subTopic,
+            status: t.status.toLowerCase(),
+            score: t.score
           }))
         }
       );


### PR DESCRIPTION
## Summary
- switch batch-update controller method to POST
- update learningTargetService batchUpdateTargets params to use `subTopic` and `score`
- adjust exam page batch update payload to match new DTO

## Testing
- `npm --prefix backend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix backend test` *(fails: jest: not found)*
- `npm --prefix frontend run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462af1e65c8327b225edee8f7bc1fb