### PR TITLE
Refactor course service and add request helper

### DIFF
--- a/frontend/src/lib/request.utils.ts
+++ b/frontend/src/lib/request.utils.ts
@@ -1,0 +1,15 @@
+import ErrorService from "@/services/error.service";
+
+export async function withErrorHandling<T>(
+  fn: () => Promise<T>,
+  message = "İşlem sırasında bir hata oluştu",
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (message) {
+      ErrorService.showToast(message, "error", "İstek");
+    }
+    throw error;
+  }
+}

--- a/frontend/src/services/course.service.ts
+++ b/frontend/src/services/course.service.ts
@@ -1,103 +1,80 @@
-﻿import apiService from "@/services/api.service";
+import apiService from "@/services/api.service";
+import { withErrorHandling } from "@/lib/request.utils";
 import { Course, CourseStats, CourseDashboard } from "@/types/course.type";
 
 class CourseService {
   async createCourse(courseData: { name: string }): Promise<Course> {
-    try {
-      // Önce mevcut kursları kontrol et
-      const existingCourses = await this.getCourses();
+    // Önce mevcut kursları kontrol et
+    const existingCourses = await this.getCourses();
 
-      // Aynı isimde bir kurs var mı kontrol et (büyük-küçük harf duyarsız)
-      const isDuplicate = existingCourses.some(
-        (course) => course.name.toLowerCase() === courseData.name.toLowerCase(),
-      );
+    // Aynı isimde bir kurs var mı kontrol et (büyük-küçük harf duyarsız)
+    const isDuplicate = existingCourses.some(
+      (course) => course.name.toLowerCase() === courseData.name.toLowerCase(),
+    );
 
-      if (isDuplicate) {
-        const errorMessage = `"${courseData.name}" adlı bir ders zaten mevcut. Lütfen farklı bir isim seçin.`;
-
-        // Özel bir hata fırlat
-        const error = new Error(errorMessage);
-        throw error;
-      }
-
-      const newCourse = await apiService.post<Course>("/courses", courseData);
-      return newCourse;
-    } catch (error) {
-      // Hata zaten oluşturulmuşsa tekrar işleme
-      if ((error as Error).message?.includes("zaten mevcut")) {
-        throw error;
-      }
-
-      // Diğer hatalar
-      throw error;
+    if (isDuplicate) {
+      const errorMessage = `"${courseData.name}" adlı bir ders zaten mevcut. Lütfen farklı bir isim seçin.`;
+      throw new Error(errorMessage);
     }
+
+    return withErrorHandling(
+      () => apiService.post<Course>("/courses", courseData),
+      "Kurs oluşturulamadı",
+    );
   }
 
   async deleteCourse(id: string): Promise<boolean> {
-    try {
-      await apiService.delete(`/courses/${id}`);
-      return true;
-    } catch (error) {
-      throw error;
-    }
+    await withErrorHandling(
+      () => apiService.delete(`/courses/${id}`),
+      "Kurs silinemedi",
+    );
+    return true;
   }
 
   async getCourses(): Promise<Course[]> {
-    try {
-      const courses = await apiService.get<Course[]>("/courses");
-      return courses;
-    } catch (error) {
-      throw error;
-    }
+    return withErrorHandling(
+      () => apiService.get<Course[]>("/courses"),
+      "Kurslar alınamadı",
+    );
   }
 
   async getCourseById(id: string): Promise<Course> {
-    try {
-      const course = await apiService.get<Course>(`/courses/${id}`);
-      return course;
-    } catch (error) {
-      throw error;
-    }
+    return withErrorHandling(
+      () => apiService.get<Course>(`/courses/${id}`),
+      "Kurs bulunamadı",
+    );
   }
 
   async getCourseStats(id: string): Promise<CourseStats> {
-    try {
-      const stats = await apiService.get<CourseStats>(`/courses/${id}/stats`);
-      return stats;
-    } catch (error) {
-      throw error;
-    }
+    return withErrorHandling(
+      () => apiService.get<CourseStats>(`/courses/${id}/stats`),
+      "Kurs istatistikleri alınamadı",
+    );
   }
 
   async getCourseDashboard(id: string): Promise<CourseDashboard> {
-    try {
-      const dashboardData = await apiService.get<CourseDashboard>(
-        `/courses/${id}/dashboard`,
-      );
-      return dashboardData;
-    } catch (error) {
-      throw error;
-    }
+    return withErrorHandling(
+      () =>
+        apiService.get<CourseDashboard>(`/courses/${id}/dashboard`),
+      "Kurs panosu alınamadı",
+    );
   }
 
   async getRelatedItemsCount(id: string): Promise<RelatedItemsCountResponse> {
-    try {
-      const counts = await apiService.get<RelatedItemsCountResponse>(
-        `/courses/${id}/related-items`,
-      );
-      return counts;
-    } catch (error) {
-      throw error;
-    }
+    return withErrorHandling(
+      () =>
+        apiService.get<RelatedItemsCountResponse>(
+          `/courses/${id}/related-items`,
+        ),
+      "İlgili öğeler alınamadı",
+    );
   }
 
   async updateCourse(id: string, courseData: Partial<Course>): Promise<Course> {
-    try {
-      const course = await apiService.put<Course>(`/courses/${id}`, courseData);
-      return course;
-    } catch (error) {
-      throw error;
-    }
+    return withErrorHandling(
+      () => apiService.put<Course>(`/courses/${id}`, courseData),
+      "Kurs güncellenemedi",
+    );
   }
 }
 

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,0 +1,11 @@
+export { default as apiService } from "./api.service";
+export { default as authService } from "./auth.service";
+export { default as courseService } from "./course.service";
+export { default as documentService } from "./document.service";
+export { default as firebaseService } from "./firebase.service";
+export { default as flowTrackerService } from "./flow-tracker.service";
+export { default as learningTargetService } from "./learningTarget.service";
+export { default as loggerService } from "./logger.service";
+export { default as quizService } from "./quiz.service";
+export * from "./adapter.service";
+export * from "./error.service";


### PR DESCRIPTION
## Summary
- add `withErrorHandling` utility for API calls
- refactor CourseService methods to reuse the helper
- add barrel file for services

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bf2e3d78832798e32e42b89e2c04